### PR TITLE
Agregando control de duplicados en parser el pais

### DIFF
--- a/notebooks/analysis_output.ipynb
+++ b/notebooks/analysis_output.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,14 +44,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['../output/el_pais/elpais20140911184708Noticias.txt', '../output/el_pais/elpais20140926203240Noticias-C.txt', '../output/el_pais/elpais20140926203240Noticias-A.txt', '../output/el_pais/elpais20140926203240Noticias-B.txt', '../output/el_pais/elpais20140924173922Noticias.txt', '../output/el_pais/elpais20140926203240Noticias-F.txt', '../output/el_pais/elpais20140926203240Noticias-E.txt', '../output/el_pais/elpais20141107112348Noticias.txt', '../output/el_pais/elpais20140926203240Noticias-D.txt', '../output/el_pais/elpais20141021181153Noticias_0.txt']\n"
+      "['../output/el_pais/el_pais.txt']\n"
      ]
     }
    ],
@@ -63,53 +63,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ANALISIS ../output/el_pais/elpais20140911184708Noticias.txt\n",
-      "  Cantidad de articulos: 106550\n",
-      "  Largo promedio de noticia: 3570.91\n",
-      "  Cantidad promedio de palabras por noticia: 594.73\n",
-      "ANALISIS ../output/el_pais/elpais20140926203240Noticias-C.txt\n",
-      "  Cantidad de articulos: 58528\n",
-      "  Largo promedio de noticia: 3798.92\n",
-      "  Cantidad promedio de palabras por noticia: 629.64\n",
-      "ANALISIS ../output/el_pais/elpais20140926203240Noticias-A.txt\n",
-      "  Cantidad de articulos: 68035\n",
-      "  Largo promedio de noticia: 3494.81\n",
-      "  Cantidad promedio de palabras por noticia: 582.86\n",
-      "ANALISIS ../output/el_pais/elpais20140926203240Noticias-B.txt\n",
-      "  Cantidad de articulos: 68098\n",
-      "  Largo promedio de noticia: 3892.66\n",
-      "  Cantidad promedio de palabras por noticia: 648.52\n",
-      "ANALISIS ../output/el_pais/elpais20140924173922Noticias.txt\n",
-      "  Cantidad de articulos: 29809\n",
-      "  Largo promedio de noticia: 4002.45\n",
-      "  Cantidad promedio de palabras por noticia: 665.35\n",
-      "ANALISIS ../output/el_pais/elpais20140926203240Noticias-F.txt\n",
-      "  Cantidad de articulos: 60839\n",
-      "  Largo promedio de noticia: 3210.84\n",
-      "  Cantidad promedio de palabras por noticia: 530.79\n",
-      "ANALISIS ../output/el_pais/elpais20140926203240Noticias-E.txt\n",
-      "  Cantidad de articulos: 61774\n",
-      "  Largo promedio de noticia: 3373.01\n",
-      "  Cantidad promedio de palabras por noticia: 558.92\n",
-      "ANALISIS ../output/el_pais/elpais20141107112348Noticias.txt\n",
-      "  Cantidad de articulos: 380\n",
-      "  Largo promedio de noticia: 2430.86\n",
-      "  Cantidad promedio de palabras por noticia: 406.13\n",
-      "ANALISIS ../output/el_pais/elpais20140926203240Noticias-D.txt\n",
-      "  Cantidad de articulos: 75277\n",
-      "  Largo promedio de noticia: 3827.63\n",
-      "  Cantidad promedio de palabras por noticia: 637.28\n",
-      "ANALISIS ../output/el_pais/elpais20141021181153Noticias_0.txt\n",
-      "  Cantidad de articulos: 82888\n",
-      "  Largo promedio de noticia: 3041.27\n",
-      "  Cantidad promedio de palabras por noticia: 502.34\n"
+      "ANALISIS ../output/el_pais/el_pais.txt\n",
+      "  Cantidad de articulos: 284352\n",
+      "  Largo promedio de noticia: 3316.65\n",
+      "  Cantidad promedio de palabras por noticia: 549.49\n"
      ]
     }
    ],
@@ -136,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -169,105 +133,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>../output/el_pais/elpais20140911184708Noticias...</td>\n",
-       "      <td>106550</td>\n",
-       "      <td>3570.91</td>\n",
-       "      <td>594.73</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>../output/el_pais/elpais20140926203240Noticias...</td>\n",
-       "      <td>58528</td>\n",
-       "      <td>3798.92</td>\n",
-       "      <td>629.64</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>../output/el_pais/elpais20140926203240Noticias...</td>\n",
-       "      <td>68035</td>\n",
-       "      <td>3494.81</td>\n",
-       "      <td>582.86</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>../output/el_pais/elpais20140926203240Noticias...</td>\n",
-       "      <td>68098</td>\n",
-       "      <td>3892.66</td>\n",
-       "      <td>648.52</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>../output/el_pais/elpais20140924173922Noticias...</td>\n",
-       "      <td>29809</td>\n",
-       "      <td>4002.45</td>\n",
-       "      <td>665.35</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>../output/el_pais/elpais20140926203240Noticias...</td>\n",
-       "      <td>60839</td>\n",
-       "      <td>3210.84</td>\n",
-       "      <td>530.79</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>../output/el_pais/elpais20140926203240Noticias...</td>\n",
-       "      <td>61774</td>\n",
-       "      <td>3373.01</td>\n",
-       "      <td>558.92</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>../output/el_pais/elpais20141107112348Noticias...</td>\n",
-       "      <td>380</td>\n",
-       "      <td>2430.86</td>\n",
-       "      <td>406.13</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>../output/el_pais/elpais20140926203240Noticias...</td>\n",
-       "      <td>75277</td>\n",
-       "      <td>3827.63</td>\n",
-       "      <td>637.28</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>../output/el_pais/elpais20141021181153Noticias...</td>\n",
-       "      <td>82888</td>\n",
-       "      <td>3041.27</td>\n",
-       "      <td>502.34</td>\n",
+       "      <td>../output/el_pais/el_pais.txt</td>\n",
+       "      <td>284352</td>\n",
+       "      <td>3316.65</td>\n",
+       "      <td>549.49</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                             archivo  cant_articulos  \\\n",
-       "0  ../output/el_pais/elpais20140911184708Noticias...          106550   \n",
-       "1  ../output/el_pais/elpais20140926203240Noticias...           58528   \n",
-       "2  ../output/el_pais/elpais20140926203240Noticias...           68035   \n",
-       "3  ../output/el_pais/elpais20140926203240Noticias...           68098   \n",
-       "4  ../output/el_pais/elpais20140924173922Noticias...           29809   \n",
-       "5  ../output/el_pais/elpais20140926203240Noticias...           60839   \n",
-       "6  ../output/el_pais/elpais20140926203240Noticias...           61774   \n",
-       "7  ../output/el_pais/elpais20141107112348Noticias...             380   \n",
-       "8  ../output/el_pais/elpais20140926203240Noticias...           75277   \n",
-       "9  ../output/el_pais/elpais20141021181153Noticias...           82888   \n",
+       "                         archivo  cant_articulos  promedio_largo_noticias  \\\n",
+       "0  ../output/el_pais/el_pais.txt          284352                  3316.65   \n",
        "\n",
-       "   promedio_largo_noticias  promedio_cantidad_palabras  \n",
-       "0                  3570.91                      594.73  \n",
-       "1                  3798.92                      629.64  \n",
-       "2                  3494.81                      582.86  \n",
-       "3                  3892.66                      648.52  \n",
-       "4                  4002.45                      665.35  \n",
-       "5                  3210.84                      530.79  \n",
-       "6                  3373.01                      558.92  \n",
-       "7                  2430.86                      406.13  \n",
-       "8                  3827.63                      637.28  \n",
-       "9                  3041.27                      502.34  "
+       "   promedio_cantidad_palabras  \n",
+       "0                      549.49  "
       ]
      },
-     "execution_count": 4,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -286,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -305,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -342,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -392,7 +275,7 @@
        "0                  2408.59                      391.94  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/src/el_pais_parser.py
+++ b/src/el_pais_parser.py
@@ -14,6 +14,7 @@ def parse_data(
 
   paths = [str(x) for x in Path(input).glob("*.xml")]
 
+  all_unique_articles = []
   for path in paths:
     print(f'Processing {path}... ')
 
@@ -39,10 +40,12 @@ def parse_data(
 
     beautified_result = list(map(utils.clean_elpais_text, beautified_result))
 
-    new_file = path.split('/')[-1].split('.')[0]
-    with open(f'{output}{new_file}.txt', "w") as f:
-      for text in beautified_result:
-          f.write(text +"\n")
+    all_unique_articles = list(set(all_unique_articles + beautified_result))
+
+  new_file = 'el_pais'
+  with open(f'{output}{new_file}.txt', "w") as f:
+    for text in all_unique_articles:
+        f.write(text +"\n")
 
 if __name__ == "__main__":
     


### PR DESCRIPTION
Elimnando noticias duplicadas
Actualizado el notebook con la  nueva salida
**IMPORTANTE:** la salida del parser de El Pais pasa a ser **un unico archivo**